### PR TITLE
fix sample Podfile in iOS版本依赖配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,11 @@ dependencies:
         symlink = File.join(symlink_plugins_dir, plugin_name)
         File.symlink(plugin_path, symlink)
 
-        pod plugin_name, :path => File.join('.symlinks', 'plugins', plugin_name, 'ios')
         if plugin_name == 'pangle_flutter'
           # cn表示国内，global表示海外
           pod 'pangle_flutter/global', :path => File.join('.symlinks', 'plugins', plugin_name, 'ios')
+        else
+          pod plugin_name, :path => File.join('.symlinks', 'plugins', plugin_name, 'ios')
         end
       end
     end


### PR DESCRIPTION
Previous code has a problem that occurs conflicting between `pangle_flutter` and `pangle_flutter/global` because both two code below will be executed.

```ruby
pod 'pangle_flutter/global', :path => File.join('.symlinks', 'plugins', plugin_name, 'ios')
pod 'pangle_flutter', :path => File.join('.symlinks', 'plugins', plugin_name, 'ios')
```

This code result in installing both two pod.
> 'Ads-CN', 'Ads-Global'

But If we use global, only later one is needed.
- https://github.com/bytedance/Bytedance-UnionAD/blob/master/Demo/InternationalDemo/Swift/Podfile
- https://www.pangleglobal.com/integration/integrate-pangle-sdk-for-ios#:~:text=to%20here%3A%20link-,Import%20Pangle%20SDK%20through%20CocoaPods(preferred)%3A,-The%20simplest%20way